### PR TITLE
prevent null error on absent parameter.properties

### DIFF
--- a/toolchain-to-template.sh
+++ b/toolchain-to-template.sh
@@ -285,7 +285,7 @@ do
 
     # suppress the value of any type:password parameter
     echo "${SERVICE_BROKERS}" |  jq -r  --arg service_id "${SERVICE_ID}" \
-      '.service_brokers[] | select( .entity.unique_id == $service_id ) | .metadata.parameters.properties | keys[] | . ' |\
+      '.service_brokers[] | select( .entity.unique_id == $service_id and .metadata.parameters.properties ) | .metadata.parameters.properties | keys[] | . ' |\
     while IFS=$'\n\r' read -r property_name 
     do
       PROPERTY_TYPE=$( echo "${SERVICE_BROKERS}" |  jq -r  --arg service_id "${SERVICE_ID}" --arg property_name "${property_name}" \


### PR DESCRIPTION
On service_broker with service_id draservicebroker,
which has no .metadata.parameters
nor .metadata.parameters.properties
it was giving error:
jq: error (at <stdin>:2025): null (null) has no keys

so updating the jq select statement to not select
where those are absent.
Part of the while loop suppressing toolchain parameters
whose schema property has type password.