### PR TITLE
updates to work with dedicated environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The toolchain-to-template script takes a Toolchain URL and will generate an OTC 
 2) Create a temporary work folder where the script will generate your template
 3) Download and copy `toolchain-to-template.sh` to your work folder
 4) Determine whether your toolchain is in the public cloud or in a dedicated environment.  
-   The following environments be detected and set PUBLIC_CLOUD=true, with other environments considered as dedicated;  
+   The following environments will be detected and will set PUBLIC_CLOUD=true, with other environments considered as dedicated;  
    - https://cloud.ibm.com/
    - https://test.cloud.ibm.com/
    - https://dev.console.test.cloud.ibm.com/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The toolchain-to-template script takes a Toolchain URL and will generate an OTC Template in the current folder that when run creates a clone of you original toolchain. For example:
 ```
-./toolchain-to-template.sh https://cloud.ibm.com/devops/toolchains/2665ce98-ea71-43e8-b723-19bafdb7a541?env_id=ibm:yp:us-east`
+./toolchain-to-template.sh https://cloud.ibm.com/devops/toolchains/2665ce98-ea71-43e8-b723-19bafdb7a541?env_id=ibm:yp:us-east
 ```
 
 ---
@@ -10,17 +10,28 @@ The toolchain-to-template script takes a Toolchain URL and will generate an OTC 
 1) The toolchain-to-template.sh script requires that the following utilities are pre-installed on your PATH: ibmcloud, curl, jq 1.6 or above (https://stedolan.github.io/jq/), and yq 3.x or 2.x (https://github.com/mikefarah/yq) 
 2) Create a temporary work folder where the script will generate your template
 3) Download and copy `toolchain-to-template.sh` to your work folder
-4) Use ibmcloud CLI to login to the account where your toolchain resides
-5) Visit your Toolchain in the browser and copy the URL
+4) Determine whether your toolchain is in the public cloud or in a dedicated environment.  
+   The following environments be detected and set PUBLIC_CLOUD=true, with other environments considered as dedicated;  
+   - https://cloud.ibm.com/
+   - https://test.cloud.ibm.com/
+   - https://dev.console.test.cloud.ibm.com/
+5) Log in to respective CLI tool:
+   - For public cloud, use `ibmcloud` CLI to login to the account where your toolchain resides
+   - For a dedicated environment, use `cf` CLI to log in to the account.  
+     The `cf` CLI installers are at: https://github.com/cloudfoundry/cli#installers-and-compressed-binaries
+6) Visit your Toolchain in the browser and copy the URL
 
 ### RUN THE SCRIPT
 In a shell run the following: `./toolchain-to-template.sh https://your-toolchain-url`
 
-The script generates a `.bluemix` folder that contains your template. To use the template create a git repo and
+The script generates a `.bluemix` folder that contains your template. To use the template, create a git repo and
 copy the `.bluemix` folder into it. Commit, push and then visit your repository on an OTC Setup/Deploy page.
 
 e.g https://cloud.ibm.com/devops/setup/deploy?env_id=ibm:yp:us-south&repository=https://your_repository_url
 
-(Note: if your repository is private add "&repository_token=your_git_access_token")
+Note: if your repository is private:
+ - on public cloud, add &repository_token=your_git_access_token
+ - on dedicated, add your personal access token in an auth@, like:  
+   https://console.dys0.bluemix.net/devops/setup/deploy?repository=https://some-token@github.dys0.bluemix.net/username/repo
 
 Open the Setup/Deploy URL in a browser and click "Create" and the template will produce a newly minted clone of your original toolchain.

--- a/toolchain-to-template.sh
+++ b/toolchain-to-template.sh
@@ -135,6 +135,7 @@ echo "Toolchain url is: $FULL_TOOLCHAIN_URL"
 BEARER_TOKEN=$(ibmcloud iam oauth-tokens --output JSON | jq -r '.iam_token')
 
 OLD_TOOLCHAIN_JSON=$(curl \
+  --fail --show-error --verbose\
   -H "Authorization: ${BEARER_TOKEN}" \
   -H "Accept: application/json" \
   -H "include: everything" \

--- a/toolchain-to-template.sh
+++ b/toolchain-to-template.sh
@@ -9,7 +9,7 @@
 # 2) Create a temporary work folder to use to generate your template
 # 3) Download and copy `toolchain-to-template.sh` to your work folder
 # 4) Determine whether your toolchain is in the public cloud or in a dedicated environment.  
-#    The following environments be detected and set PUBLIC_CLOUD=true, with other environments considered as dedicated;  
+#    The following environments will be detected and will set PUBLIC_CLOUD=true, with other environments considered as dedicated;  
 #    - https://cloud.ibm.com/
 #    - https://test.cloud.ibm.com/
 #    - https://dev.console.test.cloud.ibm.com/

--- a/toolchain-to-template.sh
+++ b/toolchain-to-template.sh
@@ -114,7 +114,7 @@ echo "$TARGET_PIPELINE_ID.yml generated"
 
 # echoing the secured properties (pipeline and stage) that can not be valued there
 echo "The following pipeline secure properties needs to be updated with appropriate values:"
-jq -r '.properties[] | select(.type=="secure") | .name' ${TARGET_PIPELINE_ID}.json
+jq -r 'select(.properties != null) | .properties[] | select(.type=="secure") | .name' ${TARGET_PIPELINE_ID}.json
 
 echo "The following stage secure properties needs to be updated with appropriate values:"
 jq -r '.stages[] | . as $stage | .properties // [] | .[] | select(.type=="secure") | [$stage.name] + [.name] | join(" - ")' ${TARGET_PIPELINE_ID}.json
@@ -151,8 +151,12 @@ OLD_TOOLCHAIN_JSON=$(curl \
 # SERVICE_BROKERS=$( echo "${OLD_TOOLCHAIN_JSON}" | jq -r '.services | { "service_brokers": . }' )
 # OLD_TOOLCHAIN_JSON=$( echo "${OLD_TOOLCHAIN_JSON}" | jq -r '.toolchain' )
 SERVICE_BROKERS=$( echo "[]" | jq -r '. | { "service_brokers": . }' )
-REGION=$( echo "${OLD_TOOLCHAIN_JSON}" | jq -r '.region_id' | sed 's/.*[:]//')
-PIPELINE_API_URL="https://pipeline-service.${REGION}.devops.cloud.ibm.com/pipeline"
+#  Note on dedicated, no region_id and domain prefix is different
+# REGION=$( echo "${OLD_TOOLCHAIN_JSON}" | jq -r '.region_id' | sed 's/.*[:]//')
+# PIPELINE_API_URL="https://pipeline-service.${REGION}.devops.cloud.ibm.com/pipeline"
+DEDICATED_DOMAIN=$(echo "${TOOLCHAIN_URL}" | sed -E 's~https://console.([^/]*)/devops.*~\1~')
+# like https://otc-pipeline-server.dys0.bluemix.net/pipeline
+PIPELINE_API_URL="https://otc-pipeline-server.${DEDICATED_DOMAIN}/pipeline"
 # echo "SERVICE_BROKERS is: ${SERVICE_BROKERS}"
 # echo "OLD_TOOLCHAIN_JSON is: ${OLD_TOOLCHAIN_JSON}"
 

--- a/toolchain-to-template.sh
+++ b/toolchain-to-template.sh
@@ -130,9 +130,16 @@ if [ -z "${TOOLCHAIN_URL}" ]; then
   exit 1 
 fi
 
-FULL_TOOLCHAIN_URL="${TOOLCHAIN_URL}&isUIRequest=true"
+# &isUIRequest=true
+FULL_TOOLCHAIN_URL="${TOOLCHAIN_URL}"
 echo "Toolchain url is: $FULL_TOOLCHAIN_URL"
-BEARER_TOKEN=$(ibmcloud iam oauth-tokens --output JSON | jq -r '.iam_token')
+# old, token for public cloud:
+# BEARER_TOKEN=$(ibmcloud iam oauth-tokens --output JSON | jq -r '.iam_token')
+# TODO detect, if 401 Not Authorized returned, try using cf auth-token instead.
+# Note cf installer downloaded from: 
+# https://github.com/cloudfoundry/cli#installers-and-compressed-binaries
+# because the mac homebrew installation gave an error.
+BEARER_TOKEN=$(cf oauth-token | grep bearer)
 
 OLD_TOOLCHAIN_JSON=$(curl \
   --fail --show-error --verbose\
@@ -141,8 +148,9 @@ OLD_TOOLCHAIN_JSON=$(curl \
   -H "include: everything" \
   "${FULL_TOOLCHAIN_URL}")
 
-SERVICE_BROKERS=$( echo "${OLD_TOOLCHAIN_JSON}" | jq -r '.services | { "service_brokers": . }' )
-OLD_TOOLCHAIN_JSON=$( echo "${OLD_TOOLCHAIN_JSON}" | jq -r '.toolchain' )
+# SERVICE_BROKERS=$( echo "${OLD_TOOLCHAIN_JSON}" | jq -r '.services | { "service_brokers": . }' )
+# OLD_TOOLCHAIN_JSON=$( echo "${OLD_TOOLCHAIN_JSON}" | jq -r '.toolchain' )
+SERVICE_BROKERS=$( echo "[]" | jq -r '. | { "service_brokers": . }' )
 REGION=$( echo "${OLD_TOOLCHAIN_JSON}" | jq -r '.region_id' | sed 's/.*[:]//')
 PIPELINE_API_URL="https://pipeline-service.${REGION}.devops.cloud.ibm.com/pipeline"
 # echo "SERVICE_BROKERS is: ${SERVICE_BROKERS}"


### PR DESCRIPTION
Note, in dedicated using cf for auth, not ibmcloud.

Also &isUIRequest=true to find service_brokers not working in dedicated,
so hard-coding dedicated service broker properties of type password.

Pipeline curl parameter is api_url on dedicated (vs external_api_url on public cloud)

Readme updates.
