### PR TITLE
fix download of classic pipeline on redacted external_api_url

### DIFF
--- a/toolchain-to-template.sh
+++ b/toolchain-to-template.sh
@@ -539,10 +539,9 @@ do
         else
           # default to classic pipeline extra work
           if [ 'true' = "${PUBLIC_CLOUD}"  ] ; then
-            PIPELINE_EXTERNAL_API_URL=$(echo "${SERVICE_PARAMETERS}" | yq read - external_api_url)
-            if [ -z "${PIPELINE_EXTERNAL_API_URL}" ] || [ 'null' = "${PIPELINE_EXTERNAL_API_URL}" ] ; then
-              PIPELINE_EXTERNAL_API_URL=$(echo "${SERVICE_PARAMETERS}" | yq read - api_url)
-            fi
+            SERVICE_DASHBOARD_URL=$(yq read "${OLD_TOOLCHAIN_JSON_FILE}" "services[${i}].dashboard_url")
+            SERVICE_REGION_ID=$(yq read "${OLD_TOOLCHAIN_JSON_FILE}" "services[${i}].region_id")
+            PIPELINE_EXTERNAL_API_URL=$(echo "${TOOLCHAIN_URL}" | awk -F/ '{print $1"//"$3}' )"${SERVICE_DASHBOARD_URL}/yaml?env_id=${SERVICE_REGION_ID}"
           else # dedicated
             PIPELINE_EXTERNAL_API_URL=$(echo "${SERVICE_PARAMETERS}" | yq read - api_url)
           fi


### PR DESCRIPTION
Due to recent redaction changes to the toolchain apis,
in the downloaded toolchain.yml service
for a pipeline with type:classic
where it used to have a value like:

external_api_url: https://pipeline-service.us-south.devops.cloud.ibm.com
   /pipeline/pipelines/6cbdcf0a-eb77-4525-a9ab-f0939f3d8ca0

it now instead has:

external_api_url: '****'

This toolchain-to-template script was attempting to use
that external_api_url value and failing while downloading
the pipeline, with an error like:

Get classic pipeline content: curl -H "Authorization: $BEARER_TOKEN" -H
"Accept: application/x-yaml"  tmp.old_toolchain.json tmp.service_0.yml
tmp.service_1.yml toolchain_2021-03-05T21-41-10.yml
Error: open 6cbdcf0a-eb77-4525-a9ab-f0939f3d8ca0.yaml: no such file or
directory


Changing to fix the error, by not using the external_api_url
for classic pipeline downloading.