### PR TITLE
check prereqs, jq 1.6, yq 2.x or 3.x

### DIFF
--- a/toolchain-to-template.sh
+++ b/toolchain-to-template.sh
@@ -264,6 +264,18 @@ if [ -z "${TOOLCHAIN_URL}" ]; then
   exit 1
 fi
 
+WRONG_JQ=$( jq --version | grep "jq-1.6" )
+if [ -z "${WRONG_JQ}" ]; then
+  echo "Unexpected prereq 'jq --version' is not 'jq-1.6'"
+  exit 1
+fi
+
+WRONG_YQ=$( yq --version |  grep "yq version [23]\." )
+if [ -z "${WRONG_YQ}" ]; then
+  echo "Unexpected prereq 'yq --version' is not 2.x or 3.x"
+  exit 1
+fi
+
 OLD_YQ=$( yq --version | grep "yq version 2." )
 if [ -z "${OLD_YQ}" ]; then
   # yq 3 and later needs option to reformat json as yml


### PR DESCRIPTION
when attempting to use old jq version 1.5
this script gave an error message like:

jq: error (at tmp-pipeline_build.json:202):
Invalid path expression near attempt to access element "inputs" of
{"inputs":[{"branch":"mast...

changing to instead give an error message:

Unexpected prereq 'jq --version' is not 'jq-1.6'

Also, when used with yq version 4.6.3
this script was giving error messages like:

Error: unknown command "write" for "yq"
Run 'yq --help' for usage.

change to instead give error message:

Unexpected prereq 'yq --version' is not 2.x or 3.x

Might add yq 4.x support at a later date.