### PR TITLE
workaround for bad broker property

### DIFF
--- a/toolchain-to-template.sh
+++ b/toolchain-to-template.sh
@@ -638,7 +638,7 @@ do
     while IFS=$'\n\r' read -r property_name
     do
       PROPERTY_TYPE=$( echo "${SERVICE_BROKERS}" |  jq -r  --arg service_id "${SERVICE_ID}" --arg property_name "${property_name}" \
-        '.service_brokers[] | select( .entity.unique_id == $service_id ) | .metadata.parameters.properties[$property_name] | .type' )
+        '.service_brokers[] | select( .entity.unique_id == $service_id ) | .metadata.parameters.properties[$property_name] | select(type == "object") | .type' )
       if [ "${PROPERTY_TYPE}" = "password"  ] ; then
         FOUND=$( yq read "${SERVICE_FILE_NAME}" "${property_name}" )
         if [ "${FOUND}" ] && [ 'null' != "${FOUND}" ]; then


### PR DESCRIPTION
Workaround for an issue in the internal test environment
where a bad broker property declaration
was of type array instead of type object,
so this script was giving error:

jq: error (at <stdin>:2744): Cannot index array with string "type"