### PR TITLE
fix, yq version 3.3.2 was detected as unexpected

### DIFF
--- a/toolchain-to-template.sh
+++ b/toolchain-to-template.sh
@@ -270,7 +270,7 @@ if [ -z "${WRONG_JQ}" ]; then
   exit 1
 fi
 
-WRONG_YQ=$( yq --version |  grep "yq version [23]\." )
+WRONG_YQ=$( yq --version 2>&1 | grep "yq version [23]\." )
 if [ -z "${WRONG_YQ}" ]; then
   echo "Unexpected prereq 'yq --version' is not 2.x or 3.x"
   exit 1


### PR DESCRIPTION
when using yq version 3.3.2, it was incorrectly outputting an error:

$ ./toolchain-to-template.sh
https://cloud.ibm.com/devops/toolchains/32ae1415-e0a8-45ee-9b0e-84596e3709ae?env_id=ibm:yp:us-south
yq version 3.3.2
Unexpected prereq 'yq --version' is not 2.x or 3.x
$

as it considered that version not to be a valid 3.x version.
Problem was that yq --version was outputting to stderr
instead of stdout.
Fix is to use yq --version output from either stderr or stdout