### PR TITLE
fix pipeline.yml incorrectly had json

### DIFF
--- a/toolchain-to-template.sh
+++ b/toolchain-to-template.sh
@@ -263,7 +263,7 @@ function download_tekton_pipeline() {
   if [ "$OLD_YQ_VERSION" = true ] ; then
     yq read "${YQ_PRETTY_PRINT}" $TARGET_PIPELINE_ID.json > $TARGET_PIPELINE_ID.yml
   else
-    yq -P $TARGET_PIPELINE_ID.json > $TARGET_PIPELINE_ID.yml
+    yq --output-format=yaml -P $TARGET_PIPELINE_ID.json > $TARGET_PIPELINE_ID.yml
   fi
 
   echo "Tekton pipeline content generated: $TARGET_PIPELINE_ID.yml"


### PR DESCRIPTION
when using yq version v4.32.1 or later
then the command line had output

09:40:41 initCommand [WARN]
JSON file output is now JSON by default (instead of yaml). Use '-oy' or '--output-format=yaml' for yaml output

and the files generated for each pipeline, like pipeline_build.yml incorrectly contained json instead of yaml content.